### PR TITLE
Updated Project.toml to solve CxxWrap package incompatibility.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,5 +8,5 @@ CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 OpenCV_jll = "33b9d88c-85f9-5d73-bd91-4e2b95a9aa0b"
 
 [compat]
-CxxWrap = "0.11, 0.12, 0.13"
+CxxWrap = "0.11, 0.12, 0.13, 0.14"
 julia = "^1.6.0"


### PR DESCRIPTION
CxxWrap has huge incompatibility problems with OpenCV as the package is not maintained for Julia 1.10. Updating CxxWrap dependencies to 0.14 should fix the problem.